### PR TITLE
Feature/2 adjust updates in week

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+-e .
+nose==1.3.7
+testing.postgresql==1.3.0
+flake8==2.5.4

--- a/threethings/cli.py
+++ b/threethings/cli.py
@@ -2,6 +2,10 @@
 import os.path
 import argh
 import json
+import logging
+import pytz
+import transaction
+
 from argh import (
     safe_input,
 )
@@ -28,8 +32,7 @@ from .email_processing import (
 from dateutil.parser import (
     parse,
 )
-import pytz
-import transaction
+
 
 DEFAULT_DATABASE_URL = 'postgresql://threethings@127.0.0.1:5432/threethings-dev'  # noqa
 DEFAULT_MANDRILL_USERNAME = 'username'
@@ -43,7 +46,6 @@ DEFAULT_CONFIGURATION = {
     'mail.tls': True,
 }
 
-import logging
 logging.basicConfig(level=logging.DEBUG)
 
 cli_mailer = None

--- a/threethings/model.py
+++ b/threethings/model.py
@@ -65,16 +65,14 @@ class StatusUpdate(Base):
     @classmethod
     def updates_in_week(cls, day_in_week):
         for_year, for_week, week_day = day_in_week.isocalendar()
-        # offset to include monday till 1700 utc (10 am PDT)
+        # Offset to include monday till 1700 utc (10 am PDT)
         # after day_in_week's isoweek.
         # This is intended to catch any last minute updates
-        # it's assumed users will not send in new updates on a monday
+        # It's assumed users will not send in new updates on a monday
+        # And assumes mail will be automatically delivered at 10 am PDT
         start_date = day_in_week - timedelta(days=(week_day - 1))
         padded_start_date = start_date + timedelta(days=1, hours=17, seconds=1)
         end_date = start_date + timedelta(days=7, hours=17)
-        import pdb
-        pdb.set_trace()
-
 
         q = Session.query(cls)
         q = q.filter(and_(

--- a/threethings/model.py
+++ b/threethings/model.py
@@ -80,6 +80,8 @@ class StatusUpdate(Base):
             cls.when <= end_date,
         ))
 
+        q = q.order_by(cls.when)
+
         return q
 
     @classmethod

--- a/threethings/model.py
+++ b/threethings/model.py
@@ -8,7 +8,6 @@ from sqlalchemy import (
     ForeignKey,
     DateTime,
     Boolean,
-    func,
 )
 from sqlalchemy.orm import (
     scoped_session,


### PR DESCRIPTION
In order to catch late Monday morning updates, pad the week out.
Assumes this will end up automated, and ideally sent around 10 am PDT
Also assumes no new updates will be sent on Monday before 10 am.