### PR TITLE
Looks like heroku-run.py does call mail.host from configs/heroku.ini.

### DIFF
--- a/configs/heroku.ini
+++ b/configs/heroku.ini
@@ -8,7 +8,7 @@ use = egg:threethings
 
 pyramid.default_locale_name = en
 
-mail.host = smtp.mandrillapp.com
+mail.host = smtp.mailgun.org
 mail.port = 587
 mail.tls = true
 


### PR DESCRIPTION
Set for mailgun.